### PR TITLE
Fix loss of events

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,12 +4,12 @@ version: 0.1.0
 authors:
   - Brian J. Cardiff <bcardiff@gmail.com>
 
-crystal: 0.35.1
+crystal: 0.36.1
 
 license: MIT
 
 libraries:
-  libfswatch: ~> 1.14
+  libfswatch: ~> 1.15
 
 development_dependencies:
   crystal_lib:


### PR DESCRIPTION
According to the [documentation](http://emcrisostomo.github.io/fswatch/doc/1.14.0/libfswatch.html/cevent_8h.html#aede20289a2fa730e3a16284eacc780c0) an array of events is passed to the `FSW_CEVENT_CALLBACK`.

* I fixes this issue
* Increased the version of fswatch to 1.15 (not really required)
* Increased the crystal version to 0.36.1 (not really required)
* Added the `focus` parameter to `_it`(not really required)