### PR TITLE
Update libfswatch version to 1.16

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,12 +4,12 @@ version: 0.1.0
 authors:
   - Brian J. Cardiff <bcardiff@gmail.com>
 
-crystal: 0.36.1
+crystal: 1.3.2
 
 license: MIT
 
 libraries:
-  libfswatch: ~> 1.15
+  libfswatch: ~> 1.16
 
 development_dependencies:
   crystal_lib:


### PR DESCRIPTION
 - Increased the version of `fswatch` to 1.16
 - Increased the Crystal version to 1.3.2 _(I can revert this if you want)_
 
 There are important updates on `fswatch` [1.16 release](https://github.com/emcrisostomo/fswatch/releases/tag/1.16.0), in particular:
 
- update FSEvents flags and add support to macOS 10.10+ features
- fix memory leak